### PR TITLE
chore: update QuestDB version for stocks example

### DIFF
--- a/kafka-questdb-connector-samples/stocks/docker-compose.yml
+++ b/kafka-questdb-connector-samples/stocks/docker-compose.yml
@@ -1,13 +1,12 @@
-version: '2.1'
+version: "2.1"
 services:
   questdb:
-    image: questdb/questdb:6.5.4
+    image: questdb/questdb:6.6.1
     expose:
       - "9009"
     ports:
       - "19000:9000"
     environment:
-      - QDB_CAIRO_COMMIT_LAG=1000
       - JAVA_OPTS=-Djava.locale.providers=JRE,SPI
       - QDB_LINE_DEFAULT_PARTITION_BY=YEAR
       - QDB_PG_SELECT_CACHE_ENABLED=false
@@ -27,14 +26,14 @@ services:
     links:
       - questdb:questdb
     environment:
-        - GF_SECURITY_ADMIN_PASSWORD=quest
-        - GF_SECURITY_ADMIN_USER=admin
-        - GF_USERS_ALLOW_SIGN_UP=false
-        - GF_USERS_ALLOW_ORG_CREATE=false
-        - GF_AUTH_ANONYMOUS_ENABLED=true
-        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-        - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
-        - GF_AUTH_ANONYMOUS_ORG_ID=1
+      - GF_SECURITY_ADMIN_PASSWORD=quest
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_USERS_ALLOW_ORG_CREATE=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
+      - GF_AUTH_ANONYMOUS_ORG_ID=1
   kafka:
     image: wurstmeister/kafka:2.13-2.8.1
     ports:
@@ -58,7 +57,7 @@ services:
       POSTGRES_PASSWORD: "postgres"
       POSTGRES_DB: "postgres"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -d postgres -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -d postgres -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Removign commit lag setting as it won't be needed for QuestDB 6.6