### PR TITLE
[feat] timestamp unit configuration

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/TimestampHelper.java
+++ b/connector/src/main/java/io/questdb/kafka/TimestampHelper.java
@@ -1,0 +1,26 @@
+package io.questdb.kafka;
+
+import java.util.concurrent.TimeUnit;
+
+public final class TimestampHelper {
+    private TimestampHelper() {
+    }
+
+    static TimeUnit guessTimestampUnits(long timestamp) {
+        if (timestamp < 10000000000000L) { // 11/20/2286, 5:46:40 PM in millis and 4/26/1970, 5:46:40 PM in micros
+            return TimeUnit.MILLISECONDS;
+        } else if (timestamp < 10000000000000000L) {
+            return TimeUnit.MICROSECONDS;
+        } else {
+            return TimeUnit.NANOSECONDS;
+        }
+    }
+
+    static TimeUnit getTimestampUnits(TimeUnit hint, long timestamp) {
+        if (hint == null) {
+            return guessTimestampUnits(timestamp);
+        } else {
+            return hint;
+        }
+    }
+}

--- a/connector/src/test/java/io/questdb/kafka/TimestampHelperTest.java
+++ b/connector/src/test/java/io/questdb/kafka/TimestampHelperTest.java
@@ -1,0 +1,52 @@
+package io.questdb.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TimestampHelperTest {
+
+    @Test
+    public void testBoundaries_auto() {
+        // 4/26/1970, 5:46:40 PM
+        Date lowerBound = new Calendar.Builder()
+                .setTimeZone(TimeZone.getTimeZone("UTC"))
+                .setDate(1970, 3, 26) // note: month is 0-based
+                .setTimeOfDay(17, 46, 40, 1)
+                .build().getTime();
+
+        // 11/20/2286, 5:46:40 PM
+        Date upperBound = new Calendar.Builder()
+                .setTimeZone(TimeZone.getTimeZone("UTC"))
+                .setDate(2286, 10, 20) // note: month is 0-based
+                .setTimeOfDay(17, 46, 39, 999)
+                .build().getTime();
+
+        assertEquals(TimeUnit.MILLISECONDS, TimestampHelper.getTimestampUnits(null, lowerBound.getTime()));
+        assertEquals(TimeUnit.MILLISECONDS, TimestampHelper.getTimestampUnits(null, upperBound.getTime()));
+
+        assertEquals(TimeUnit.MICROSECONDS, TimestampHelper.getTimestampUnits(null, lowerBound.getTime() * 1000));
+        assertEquals(TimeUnit.MICROSECONDS, TimestampHelper.getTimestampUnits(null, upperBound.getTime() * 1000));
+
+        assertEquals(TimeUnit.NANOSECONDS, TimestampHelper.getTimestampUnits(null, lowerBound.getTime() * 1000000));
+        assertEquals(TimeUnit.NANOSECONDS, TimestampHelper.getTimestampUnits(null, Long.MAX_VALUE)); //upper bound in nanos does not fit in long
+    }
+
+    @Test
+    public void testBoundaries_explicit() {
+        assertEquals(TimeUnit.MILLISECONDS, TimestampHelper.getTimestampUnits(TimeUnit.MILLISECONDS, 0));
+        assertEquals(TimeUnit.MILLISECONDS, TimestampHelper.getTimestampUnits(TimeUnit.MILLISECONDS, Long.MAX_VALUE));
+
+        assertEquals(TimeUnit.MICROSECONDS, TimestampHelper.getTimestampUnits(TimeUnit.MICROSECONDS, 0));
+        assertEquals(TimeUnit.MICROSECONDS, TimestampHelper.getTimestampUnits(TimeUnit.MICROSECONDS, Long.MAX_VALUE));
+
+        assertEquals(TimeUnit.NANOSECONDS, TimestampHelper.getTimestampUnits(TimeUnit.NANOSECONDS, 0));
+        assertEquals(TimeUnit.NANOSECONDS, TimestampHelper.getTimestampUnits(TimeUnit.NANOSECONDS, Long.MAX_VALUE));
+    }
+
+}

--- a/kafka-questdb-connector-samples/stocks/pom.xml
+++ b/kafka-questdb-connector-samples/stocks/pom.xml
@@ -79,6 +79,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>io.questdb.kafka.samples.StocksApp</mainClass>
                 </configuration>

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ The connector supports following Options:
 | value.prefix           | STRING  | from_value                                                  | N/A                | Prefix for value fields                                    |
 | skip.unsupported.types | BOOLEAN | false                                                       | false              | Skip unsupported types                                     |
 | timestamp.field.name   | STRING  | pickup_time                                                 | N/A                | Designated timestamp field name                            |
+| timestamp.units        | STRING  | micros                                                      | auto               | Designated timestamp field units                           |
 | include.key            | BOOLEAN | false                                                       | true               | Include message key in target table                        |
 | symbols                | STRING  | instrument,stock                                            | N/A                | Comma separated list of columns that should be symbol type |
 | username               | STRING  | user1                                                       | admin              | User name for QuestDB. Used only when token is non-empty   |
@@ -76,7 +77,7 @@ The connector will create a table with the following columns:
 | John                        | Doe                        | 30                  | Main Street                      | New York                       |
 
 ## Designated Timestamps
-The connector supports designated timestamps. If the message contains a field with a timestamp, the connector can use it as a timestamp for the row. The field name must be configured using `timestamp.field.name` option. The field must either a simple number or a timestamp. When it's a simple number, the connector will interpret it as a Unix timestamp in milliseconds.
+The connector supports designated timestamps. If a message contains a field with a timestamp, the connector can use it as a timestamp for the row. The field name must be configured using `timestamp.field.name` option. The field must either a plain integer or being labelled as a timestamp in a message schema. When it's a plain integer, the connector will autodetect its units. This works for timestamps after 4/26/1970, 5:46:40 PM. The units can be also configured explicitly using `timestamp.units` option. Supported configuration values are `nanos`, `micros`, `millis` and `auto`. 
 
 ## QuestDB Symbol Type
 QuestDB supports a special type called [Symbol](https://questdb.io/docs/concept/symbol/). This connector never creates a column with a type `SYMBOL`. Instead, it creates a column with a type `STRING`. If you want to use `SYMBOL` type, you can pre-create a table in QuestDB and use it as a target table.


### PR DESCRIPTION
Introduce an option to explicitly configure units of timestamp in messages. 
Default units are changed from millis to "auto" which detects units for timestamps after 4/26/1970, 5:46:40 PM