### PR TITLE
feat: native support for parsing string timestamps

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -120,7 +120,7 @@
                             <goal>kafka-connect</goal>
                         </goals>
                         <configuration>
-                            <title>Kafka Connect QuestDB</title>
+                            <title>QuestDB Kafka Connector</title>
                             <documentationUrl>https://questdb.io/docs/third-party-tools/kafka/questdb-kafka/</documentationUrl>
                             <description>
                                 QuestDB Sink connector for Apache Kafka. QuestDB is a columnar time-series database with

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
@@ -8,7 +8,6 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.errors.ConnectException;
 
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -106,7 +105,7 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
         return getString(TABLE_CONFIG);
     }
 
-    public String getDefaultTimestampFormat() {
+    public String getTimestampFormat() {
         return getString(TIMESTAMP_FORMAT);
     }
 

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
@@ -38,7 +38,7 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
     private static final String TIMESTAMP_STRING_FIELDS_DOC = "Comma separated list of string fields that should be parsed as timestamp.";
 
     public static final String TIMESTAMP_UNITS_CONFIG = "timestamp.units";
-    private static final String TIMESTAMP_UNITS_DOC = "Units of timestamp field. Possible values: auto, millis, micros, nanos";
+    private static final String TIMESTAMP_UNITS_DOC = "Units of designated timestamp field. Possible values: auto, millis, micros, nanos";
 
     public static final String INCLUDE_KEY_CONFIG = "include.key";
     private static final String INCLUDE_KEY_DOC = "Include key in the table";
@@ -64,8 +64,8 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
     public static final String MAX_RETRIES = "max.retries";
     private static final String MAX_RETRIES_DOC = "The maximum number of times to retry on errors before failing the task";
 
-    public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
-    private static final String TIMESTAMP_FORMAT_DOC = "Default timestamp format";
+    public static final String TIMESTAMP_FORMAT = "timestamp.string.format";
+    private static final String TIMESTAMP_FORMAT_DOC = "Default timestamp format. Used when parsing timestamp string fields";
 
     private static final String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
 
@@ -199,11 +199,6 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
         public void ensureValid(String name, Object value) {
             if (!(value instanceof String)) {
                 throw new ConfigException(name, value, "Timestamp format must be a string");
-            }
-            try {
-                DateTimeFormatter.ofPattern((String) value);
-            } catch (IllegalArgumentException e) {
-                throw new ConfigException(name, value, "Timestamp format is not a valid DateTimeFormatter pattern. Error='" + e.getMessage() + "'");
             }
         }
     }

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
@@ -34,7 +34,7 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
     private static final String DESIGNATED_TIMESTAMP_COLUMN_NAME_DOC = "Designated timestamp field name";
 
     public static final String TIMESTAMP_STRING_FIELDS = "timestamp.string.fields";
-    private static final String TIMESTAMP_STRING_FIELDS_DOC = "Comma separated list of string fields that should be parsed as timestamp.";
+    private static final String TIMESTAMP_STRING_FIELDS_DOC = "Comma-separated list of string fields that should be parsed as timestamps.";
 
     public static final String TIMESTAMP_UNITS_CONFIG = "timestamp.units";
     private static final String TIMESTAMP_UNITS_DOC = "Units of designated timestamp field. Possible values: auto, millis, micros, nanos";
@@ -64,7 +64,7 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
     private static final String MAX_RETRIES_DOC = "The maximum number of times to retry on errors before failing the task";
 
     public static final String TIMESTAMP_FORMAT = "timestamp.string.format";
-    private static final String TIMESTAMP_FORMAT_DOC = "Default timestamp format. Used when parsing timestamp string fields";
+    private static final String TIMESTAMP_FORMAT_DOC = "Timestamp format. Used when parsing timestamp string fields";
 
     private static final String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
 

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -61,7 +61,7 @@ public final class QuestDBSinkTask extends SinkTask {
             for (String symbolColumn : timestampStringFields.split(",")) {
                 stringTimestampColumns.add(symbolColumn.trim());
             }
-            dataFormat = TimestampParserCompiler.compilePattern(config.getDefaultTimestampFormat());
+            dataFormat = TimestampParserCompiler.compilePattern(config.getTimestampFormat());
         } else {
             stringTimestampColumns = Collections.emptySet();
         }
@@ -314,7 +314,9 @@ public final class QuestDBSinkTask extends SinkTask {
         try {
             return dataFormat.parse(timestamp, DateFormatUtils.enLocale);
         } catch (NumericException e) {
-            throw new ConnectException("Cannot parse timestamp: " + timestamp, e);
+            throw new ConnectException("Cannot parse timestamp: " + timestamp + " with the configured format '" + config.getTimestampFormat() +"' use '"
+                    + QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT + "' to configure the right timestamp format. " +
+                    "See https://questdb.io/docs/reference/function/date-time/#date-and-timestamp-format for timestamp parser documentation. ", e);
         }
     }
 

--- a/connector/src/main/java/io/questdb/kafka/TimestampParserCompiler.java
+++ b/connector/src/main/java/io/questdb/kafka/TimestampParserCompiler.java
@@ -7,16 +7,14 @@ import io.questdb.std.datetime.microtime.TimestampFormatCompiler;
 class TimestampParserCompiler {
     private static TimestampFormatCompiler compiler;
     private static final Object MUTEX = new Object();
-    // we assume that there will just a few patterns
+    // we assume that there will just a few patterns hence to issue with unbounded cache growth
     private static CharSequenceObjHashMap<DateFormat> cache;
 
     public static DateFormat compilePattern(String timestampPattern) {
         synchronized (MUTEX) {
             if (compiler == null) {
                 compiler = new TimestampFormatCompiler();
-            }
-            // DateFormat instances are thread-safe, so we can cache them and use for multiple workers
-            if (cache == null) {
+                // DateFormat instances are thread-safe, so we can cache them and use for multiple workers
                 cache = new CharSequenceObjHashMap<>();
             }
             DateFormat format = cache.get(timestampPattern);

--- a/connector/src/main/java/io/questdb/kafka/TimestampParserCompiler.java
+++ b/connector/src/main/java/io/questdb/kafka/TimestampParserCompiler.java
@@ -1,0 +1,31 @@
+package io.questdb.kafka;
+
+import io.questdb.std.CharSequenceObjHashMap;
+import io.questdb.std.datetime.DateFormat;
+import io.questdb.std.datetime.microtime.TimestampFormatCompiler;
+
+class TimestampParserCompiler {
+    private static TimestampFormatCompiler compiler;
+    private static final Object MUTEX = new Object();
+    // we assume that there will just a few patterns
+    private static CharSequenceObjHashMap<DateFormat> cache;
+
+    public static DateFormat compilePattern(String timestampPattern) {
+        synchronized (MUTEX) {
+            if (compiler == null) {
+                compiler = new TimestampFormatCompiler();
+            }
+            // DateFormat instances are thread-safe, so we can cache them and use for multiple workers
+            if (cache == null) {
+                cache = new CharSequenceObjHashMap<>();
+            }
+            DateFormat format = cache.get(timestampPattern);
+            if (format != null) {
+                return format;
+            }
+            format = compiler.compile(timestampPattern);
+            cache.put(timestampPattern, format);
+            return format;
+        }
+    }
+}

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -747,7 +747,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         props.put("value.converter.schemas.enable", "false");
         props.put(QuestDBSinkConnectorConfig.DESIGNATED_TIMESTAMP_COLUMN_NAME_CONFIG, "born");
         props.put(QuestDBSinkConnectorConfig.INCLUDE_KEY_CONFIG, "false");
-        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.U+ z");
+        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.SSSUUU z");
         props.put(QuestDBSinkConnectorConfig.TIMESTAMP_STRING_FIELDS, "born,death");
 
         connect.configureConnector(CONNECTOR_NAME, props);

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -458,14 +458,14 @@ public final class QuestDBSinkConnectorEmbeddedTest {
     }
 
     @Test
-    public void testTimestampSMT_parseMicroseconds_schemaLess() {
+    public void testTimestampSMT_parseTimestamp_schemaLess() {
         connect.kafka().createTopic(topicName, 1);
         Map<String, String> props = baseConnectorProps(topicName);
         props.put("value.converter.schemas.enable", "false");
         props.put(QuestDBSinkConnectorConfig.DESIGNATED_TIMESTAMP_COLUMN_NAME_CONFIG, "born");
         props.put(QuestDBSinkConnectorConfig.INCLUDE_KEY_CONFIG, "false");
 
-        String timestampFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS z";
+        String timestampFormat = "yyyy-MM-dd HH:mm:ss.SSS z";
         props.put("transforms", "Timestamp-born,Timestamp-death");
         props.put("transforms.Timestamp-born.type", "org.apache.kafka.connect.transforms.TimestampConverter$Value");
         props.put("transforms.Timestamp-born.field", "born");
@@ -485,8 +485,8 @@ public final class QuestDBSinkConnectorEmbeddedTest {
                 "create table " + topicName + " (firstname string, lastname string, death timestamp, born timestamp) timestamp(born)",
                 QuestDBUtils.Endpoint.EXEC);
 
-        String birthTimestamp = "1985-08-02 16:41:55.402095 UTC";
-        String deadTimestamp = "2023-08-02 16:41:55.402095 UTC";
+        String birthTimestamp = "1985-08-02 16:41:55.402 UTC";
+        String deadTimestamp = "2023-08-02 16:41:55.402 UTC";
         connect.kafka().produce(topicName, "foo",
                 "{\"firstname\":\"John\""
                         + ",\"lastname\":\"Doe\""
@@ -495,18 +495,18 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         );
 
         QuestDBUtils.assertSqlEventually(questDBContainer, "\"firstname\",\"lastname\",\"death\",\"born\"\r\n" +
-                        "\"John\",\"Doe\",\"2023-08-02T16:48:37.095000Z\",\"1985-08-02T16:48:37.095000Z\"\r\n",
+                        "\"John\",\"Doe\",\"2023-08-02T16:41:55.402000Z\",\"1985-08-02T16:41:55.402000Z\"\r\n",
                 "select * from " + topicName);
     }
 
     @Test
-    public void testTimestampSMT_parseMicroseconds_withSchema() {
+    public void testTimestampSMT_parseTimestamp_withSchema() {
         connect.kafka().createTopic(topicName, 1);
         Map<String, String> props = baseConnectorProps(topicName);
         props.put(QuestDBSinkConnectorConfig.DESIGNATED_TIMESTAMP_COLUMN_NAME_CONFIG, "born");
         props.put(QuestDBSinkConnectorConfig.INCLUDE_KEY_CONFIG, "false");
 
-        String timestampFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS z";
+        String timestampFormat = "yyyy-MM-dd HH:mm:ss.SSS z";
         props.put("transforms", "Timestamp-born,Timestamp-death");
         props.put("transforms.Timestamp-born.type", "org.apache.kafka.connect.transforms.TimestampConverter$Value");
         props.put("transforms.Timestamp-born.field", "born");
@@ -530,14 +530,14 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         Struct struct = new Struct(schema)
                 .put("firstname", "John")
                 .put("lastname", "Doe")
-                .put("born", "1985-08-02 16:41:55.402095 UTC")
-                .put("death", "2023-08-02 16:41:55.402095 UTC");
+                .put("born", "1985-08-02 16:41:55.402 UTC")
+                .put("death", "2023-08-02 16:41:55.402 UTC");
 
 
         connect.kafka().produce(topicName, "key", new String(converter.fromConnectData(topicName, schema, struct)));
 
         QuestDBUtils.assertSqlEventually(questDBContainer, "\"firstname\",\"lastname\",\"death\",\"timestamp\"\r\n" +
-                        "\"John\",\"Doe\",\"2023-08-02T16:48:37.095000Z\",\"1985-08-02T16:48:37.095000Z\"\r\n",
+                        "\"John\",\"Doe\",\"2023-08-02T16:41:55.402000Z\",\"1985-08-02T16:41:55.402000Z\"\r\n",
                 "select * from " + topicName);
     }
 
@@ -738,6 +738,38 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         QuestDBUtils.assertSqlEventually(questDBContainer, "\"firstname\",\"lastname\",\"age\",\"key\"\r\n"
                         + "\"John\",\"Doe\",42,\"key\"\r\n",
                 "select firstname, lastname, age, key from " + topicName);
+    }
+
+    @Test
+    public void testParsingStringTimestamp() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = baseConnectorProps(topicName);
+        props.put("value.converter.schemas.enable", "false");
+        props.put(QuestDBSinkConnectorConfig.DESIGNATED_TIMESTAMP_COLUMN_NAME_CONFIG, "born");
+        props.put(QuestDBSinkConnectorConfig.INCLUDE_KEY_CONFIG, "false");
+        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.SSSSSS z");
+        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_STRING_FIELDS, "born,death");
+
+        connect.configureConnector(CONNECTOR_NAME, props);
+        assertConnectorTaskRunningEventually();
+
+        QuestDBUtils.assertSql(questDBContainer,
+                "{\"ddl\":\"OK\"}\n",
+                "create table " + topicName + " (firstname string, lastname string, death timestamp, born timestamp) timestamp(born)",
+                QuestDBUtils.Endpoint.EXEC);
+
+        String birthTimestamp = "1985-08-02 16:41:55.402095 UTC";
+        String deadTimestamp = "2023-08-02 16:41:55.402095 UTC";
+        connect.kafka().produce(topicName, "foo",
+                "{\"firstname\":\"John\""
+                        + ",\"lastname\":\"Doe\""
+                        + ",\"death\":\"" + deadTimestamp + "\""
+                        + ",\"born\":\"" + birthTimestamp + "\"}"
+        );
+
+        QuestDBUtils.assertSqlEventually(questDBContainer, "\"firstname\",\"lastname\",\"death\",\"born\"\r\n" +
+                        "\"John\",\"Doe\",\"2023-08-02T16:41:55.402095Z\",\"1985-08-02T16:41:55.402095Z\"\r\n",
+                "select * from " + topicName);
     }
 
     @Test

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -747,7 +747,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         props.put("value.converter.schemas.enable", "false");
         props.put(QuestDBSinkConnectorConfig.DESIGNATED_TIMESTAMP_COLUMN_NAME_CONFIG, "born");
         props.put(QuestDBSinkConnectorConfig.INCLUDE_KEY_CONFIG, "false");
-        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.SSSSSS z");
+        props.put(QuestDBSinkConnectorConfig.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.U+ z");
         props.put(QuestDBSinkConnectorConfig.TIMESTAMP_STRING_FIELDS, "born,death");
 
         connect.configureConnector(CONNECTOR_NAME, props);


### PR DESCRIPTION
The [TimestampTransform](https://docs.confluent.io/platform/current/connect/transforms/timestampconverter.html) shipped with Kafka Connect does not support microseconds at all. 

Native support also means users are not forced to learn about Kafka Connect SMT. It's been proven difficult in cases where users just want to move data from Kafka to QuestDB, but are not Kafka experts. 

This PR introduces 2 new properties:
`timestamp.string.fields` - Comma-separated list of string fields that should be parsed as timestamps. 
`timestamp.string.format` - Timestamp format. Used when parsing timestamp string fields. See https://questdb.io/docs/reference/function/date-time/#date-and-timestamp-format for info about formatting. 


