### PR TITLE
fix: regression in auth token configuration

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
@@ -6,6 +6,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import java.util.Arrays;
@@ -153,8 +154,8 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
         return getString(USERNAME);
     }
 
-    public String getToken() {
-        return getPassword(TOKEN).value();
+    public Password getToken() {
+        return getPassword(TOKEN);
     }
 
     public boolean isTls() {

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkConnectorConfig.java
@@ -154,7 +154,7 @@ public final class QuestDBSinkConnectorConfig extends AbstractConfig {
     }
 
     public String getToken() {
-        return getString(TOKEN);
+        return getPassword(TOKEN).value();
     }
 
     public boolean isTls() {

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -9,12 +9,7 @@ import io.questdb.std.datetime.millitime.DateFormatUtils;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.*;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -22,12 +17,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public final class QuestDBSinkTask extends SinkTask {
@@ -91,10 +81,10 @@ public final class QuestDBSinkTask extends SinkTask {
         }
         if (config.getToken() != null) {
             String username = config.getUsername();
-            if (username == null || username.equals("")) {
+            if (username == null || username.isEmpty()) {
                 throw new ConnectException("Username cannot be empty when using ILP authentication");
             }
-            builder.enableAuth(username).authToken(config.getToken());
+            builder.enableAuth(username).authToken(config.getToken().value());
         }
         Sender rawSender = builder.build();
         String symbolColumns = config.getSymbolColumns();

--- a/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
+++ b/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
@@ -1,0 +1,77 @@
+package io.questdb.kafka;
+
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public final class ConnectTestUtils {
+    public static final long CONNECTOR_START_TIMEOUT_MS = SECONDS.toMillis(60);
+    public static final String CONNECTOR_NAME = "questdb-sink-connector";
+    private static final AtomicInteger ID_GEN = new AtomicInteger(0);
+
+    private ConnectTestUtils() {
+    }
+
+    static void assertConnectorTaskRunningEventually(EmbeddedConnectCluster connect) {
+        assertConnectorTaskStateEventually(connect, AbstractStatus.State.RUNNING);
+    }
+
+    static void assertConnectorTaskFailedEventually(EmbeddedConnectCluster connect) {
+        assertConnectorTaskStateEventually(connect, AbstractStatus.State.FAILED);
+    }
+
+    static void assertConnectorTaskStateEventually(EmbeddedConnectCluster connect, AbstractStatus.State expectedState) {
+        Awaitility.await().atMost(CONNECTOR_START_TIMEOUT_MS, MILLISECONDS).untilAsserted(() -> assertConnectorTaskState(connect, CONNECTOR_NAME, expectedState));
+    }
+
+    static Map<String, String> baseConnectorProps(GenericContainer<?> questDBContainer, String topicName) {
+        Map<String, String> props = new HashMap<>();
+        props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, QuestDBSinkConnector.class.getName());
+        props.put("topics", topicName);
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        props.put("host", questDBContainer.getHost() + ":" + questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_ILP_PORT));
+        return props;
+    }
+
+    static void assertConnectorTaskState(EmbeddedConnectCluster connect, String connectorName, AbstractStatus.State expectedState) {
+        ConnectorStateInfo info = connect.connectorStatus(connectorName);
+        if (info == null) {
+            fail("Connector " + connectorName + " not found");
+        }
+        List<ConnectorStateInfo.TaskState> taskStates = info.tasks();
+        if (taskStates.size() == 0) {
+            fail("No tasks found for connector " + connectorName);
+        }
+        for (ConnectorStateInfo.TaskState taskState : taskStates) {
+            if (!Objects.equals(taskState.state(), expectedState.toString())) {
+                fail("Task " + taskState.id() + " for connector " + connectorName + " is in state " + taskState.state() + " but expected " + expectedState);
+            }
+        }
+    }
+
+    static String newTopicName() {
+        return "topic" + ID_GEN.getAndIncrement();
+    }
+
+    static String newTableName() {
+        return "table" + ID_GEN.getAndIncrement();
+    }
+}

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
@@ -29,6 +29,10 @@ public class QuestDBSinkConnectorEmbeddedAuthTest {
     private Converter converter;
     private String topicName;
 
+    // must match the user in authDb.txt
+    private static final String TEST_USER_TOKEN = "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw=";
+    private static final String TEST_USER_NAME = "testUser1";
+
     @Container
     private static GenericContainer<?> questDBContainer = newQuestDbConnector();
 
@@ -60,8 +64,8 @@ public class QuestDBSinkConnectorEmbeddedAuthTest {
     public void testSmoke() {
         connect.kafka().createTopic(topicName, 1);
         Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName);
-        props.put(QuestDBSinkConnectorConfig.USERNAME, "testUser1");
-        props.put(QuestDBSinkConnectorConfig.TOKEN, "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw=");
+        props.put(QuestDBSinkConnectorConfig.USERNAME, TEST_USER_NAME);
+        props.put(QuestDBSinkConnectorConfig.TOKEN, TEST_USER_TOKEN);
 
         connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
         ConnectTestUtils.assertConnectorTaskRunningEventually(connect);

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
@@ -1,0 +1,96 @@
+package io.questdb.kafka;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.ConverterType;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@Testcontainers
+public class QuestDBSinkConnectorEmbeddedAuthTest {
+    private static final String CONNECTOR_NAME = "questdb-sink-connector";
+    private static final long CONNECTOR_START_TIMEOUT_MS = SECONDS.toMillis(60);
+
+    private EmbeddedConnectCluster connect;
+    private Converter converter;
+
+    private static final AtomicInteger ID_GEN = new AtomicInteger(0);
+    private String topicName;
+
+    @Container
+    private static GenericContainer<?> questDBContainer = newQuestDbConnector();
+
+    private static GenericContainer<?> newQuestDbConnector() {
+        FixedHostPortGenericContainer<?> container = new FixedHostPortGenericContainer<>("questdb/questdb:7.3");
+        container.addExposedPort(QuestDBUtils.QUESTDB_HTTP_PORT);
+        container.addExposedPort(QuestDBUtils.QUESTDB_ILP_PORT);
+        container.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*server-main enjoy.*"));
+        container.withCopyFileToContainer(MountableFile.forClasspathResource("/authDb.txt"), "/var/lib/questdb/conf/authDb.txt");
+        container.withEnv("QDB_LINE_TCP_AUTH_DB_PATH", "conf/authDb.txt");
+        return container.withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("questdb")));
+    }
+
+    private static String newTopicName() {
+        return "topic" + ID_GEN.getAndIncrement();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        topicName = newTopicName();
+        JsonConverter jsonConverter = new JsonConverter();
+        jsonConverter.configure(singletonMap(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName()));
+        converter = jsonConverter;
+
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("questdb-connect-cluster")
+                .build();
+
+        connect.start();
+    }
+
+    @Test
+    public void testSmoke() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName);
+        props.put(QuestDBSinkConnectorConfig.USERNAME, "testUser1");
+        props.put(QuestDBSinkConnectorConfig.TOKEN, "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw=");
+
+        connect.configureConnector(CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+        Schema schema = SchemaBuilder.struct().name("com.example.Person")
+                .field("firstname", Schema.STRING_SCHEMA)
+                .field("lastname", Schema.STRING_SCHEMA)
+                .field("age", Schema.INT8_SCHEMA)
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("firstname", "John")
+                .put("lastname", "Doe")
+                .put("age", (byte) 42);
+
+        connect.kafka().produce(topicName, "key", new String(converter.fromConnectData(topicName, schema, struct)));
+
+        QuestDBUtils.assertSqlEventually(questDBContainer, "\"firstname\",\"lastname\",\"age\"\r\n"
+                        + "\"John\",\"Doe\",42\r\n",
+                "select firstname,lastname,age from " + topicName);
+    }
+}

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedAuthTest.java
@@ -20,20 +20,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.singletonMap;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Testcontainers
 public class QuestDBSinkConnectorEmbeddedAuthTest {
-    private static final String CONNECTOR_NAME = "questdb-sink-connector";
-    private static final long CONNECTOR_START_TIMEOUT_MS = SECONDS.toMillis(60);
-
     private EmbeddedConnectCluster connect;
     private Converter converter;
-
-    private static final AtomicInteger ID_GEN = new AtomicInteger(0);
     private String topicName;
 
     @Container
@@ -49,13 +42,9 @@ public class QuestDBSinkConnectorEmbeddedAuthTest {
         return container.withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("questdb")));
     }
 
-    private static String newTopicName() {
-        return "topic" + ID_GEN.getAndIncrement();
-    }
-
     @BeforeEach
     public void setUp() {
-        topicName = newTopicName();
+        topicName = ConnectTestUtils.newTopicName();
         JsonConverter jsonConverter = new JsonConverter();
         jsonConverter.configure(singletonMap(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName()));
         converter = jsonConverter;
@@ -74,7 +63,7 @@ public class QuestDBSinkConnectorEmbeddedAuthTest {
         props.put(QuestDBSinkConnectorConfig.USERNAME, "testUser1");
         props.put(QuestDBSinkConnectorConfig.TOKEN, "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw=");
 
-        connect.configureConnector(CONNECTOR_NAME, props);
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
         ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
         Schema schema = SchemaBuilder.struct().name("com.example.Person")
                 .field("firstname", Schema.STRING_SCHEMA)

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -42,10 +42,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Testcontainers
 public final class QuestDBSinkConnectorEmbeddedTest {
-
     private EmbeddedConnectCluster connect;
     private Converter converter;
-
     private String topicName;
 
     @Container

--- a/connector/src/test/resources/authDb.txt
+++ b/connector/src/test/resources/authDb.txt
@@ -1,0 +1,19 @@
+# Test auth db file, format is
+# [key/user id] [key type] {key details} ...
+# Only elliptic curve (for curve P-256) are supported (key type ec-p-256-sha256), the key details for such a key are the base64url encoded x and y points that determine the public key as defined in the JSON web token standard (RFC 7519)
+#
+# The auth db file needs to be put somewhere in the questdbn server root and referenced in the line.tcp.auth.db.path setting of server conf, like:
+# line.tcp.auth.db.path=conf/authDb.txt
+#
+# Below is an elliptic curve (for curve P-256) JSON Web Key
+#{
+#  "kty": "EC",
+#  "d": "5UjEMuA0Pj5pjK8a-fa24dyIf-Es5mYny3oE_Wmus48",
+#  "crv": "P-256",
+#  "kid": "testUser1",
+#  "x": "fLKYEaoEb9lrn3nkwLDA-M_xnuFOdSt9y0Z7_vWSHLU",
+#  "y": "Dt5tbS1dEDMSYfym3fgMv0B99szno-dFc1rYF9t0aac"
+#}
+# For this kind of key the "d" parameter is used to generate the secret key. The "x" and "y" parameters are used to generate the public key
+testUser1	ec-p-256-sha256	AKfkxOBlqBN8uDfTxu2Oo6iNsOPBnXkEH4gt44tBJKCY	AL7WVjoH-IfeX_CXo5G1xXKp_PqHUrdo3xeRyDuWNbBX
+


### PR DESCRIPTION
The regression was caused by masking the auth token so Kafka Connect would not log it. For avoidable for doubts: This issue could not be abused to get an unauthorized access to QuestDB.