### PR TITLE
feat: disable interval-based auto-flushes by default

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
+++ b/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
@@ -1,0 +1,66 @@
+package io.questdb.kafka;
+
+import io.questdb.client.impl.ConfStringParser;
+import io.questdb.std.Chars;
+import io.questdb.std.str.StringSink;
+
+final class ClientConfUtils {
+    private ClientConfUtils() {
+    }
+
+    static boolean patchConfStr(String confStr, StringSink sink) {
+        int pos = ConfStringParser.of(confStr, sink);
+        if (pos < 0) {
+            sink.clear();
+            sink.put(confStr);
+            return false;
+        }
+
+        boolean isHttpTransport = Chars.equals(sink, "http") || Chars.equals(sink, "https");
+        boolean intervalFlushSetExplicitly = false;
+        boolean flushesDisabled = false;
+        boolean parseError = false;
+        boolean hasAtLeastOneParam = false;
+
+        // disable interval based flushes
+        // unless they are explicitly set or auto_flush is entirely off
+        // why? the connector has its own mechanism to flush data in a timely manner
+        while (ConfStringParser.hasNext(confStr, pos)) {
+            hasAtLeastOneParam = true;
+            pos = ConfStringParser.nextKey(confStr, pos, sink);
+            if (pos < 0) {
+                parseError = true;
+                break;
+            }
+            if (Chars.equals(sink, "auto_flush_interval")) {
+                intervalFlushSetExplicitly = true;
+                pos = ConfStringParser.value(confStr, pos, sink);
+            } else if (Chars.equals(sink, "auto_flush")) {
+                pos = ConfStringParser.value(confStr, pos, sink);
+                flushesDisabled = Chars.equals(sink, "off");
+            } else {
+                pos = ConfStringParser.value(confStr, pos, sink); // skip other values
+            }
+            if (pos < 0) {
+                parseError = true;
+                break;
+            }
+        }
+        sink.clear();
+        sink.put(confStr);
+        if (!parseError // we don't want to mess with the config if there was a parse error
+                && isHttpTransport // we only want to patch http transport
+                && !flushesDisabled // if auto-flush is disabled we don't need to do anything
+                && !intervalFlushSetExplicitly // if auto_flush_interval is set explicitly we don't want to override it
+                && hasAtLeastOneParam // no parameter is also an error since at least address should be set. we let client throw exception in this case
+        ) {
+            // if everything is ok, we set auto_flush_interval to max value
+            // this will effectively disable interval based flushes
+            // and the connector will flush data only when it is told to do so by Connector
+            // or if a row count limit is reached
+            sink.put("auto_flush_interval=").put(Integer.MAX_VALUE).put(';');
+        }
+
+        return isHttpTransport;
+    }
+}

--- a/connector/src/test/java/io/questdb/kafka/ClientConfUtilsTest.java
+++ b/connector/src/test/java/io/questdb/kafka/ClientConfUtilsTest.java
@@ -1,0 +1,55 @@
+package io.questdb.kafka;
+
+import io.questdb.std.Chars;
+import io.questdb.std.str.StringSink;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClientConfUtilsTest {
+
+    @Test
+    public void testHttpTransportIsResolved() {
+        StringSink sink = new StringSink();
+        assertTrue(ClientConfUtils.patchConfStr("http::addr=localhost:9000;", sink));
+        assertTrue(ClientConfUtils.patchConfStr("https::addr=localhost:9000;", sink));
+        assertTrue(ClientConfUtils.patchConfStr("https::addr=localhost:9000;", sink));
+        assertFalse(ClientConfUtils.patchConfStr("tcp::addr=localhost:9000;", sink));
+        assertFalse(ClientConfUtils.patchConfStr("tcps::addr=localhost:9000;", sink));
+    }
+
+    @Test
+    public void testHttpTransportTimeBasedFlushesDisabledByDefault() {
+        assertConfStringIsPatched("http::addr=localhost:9000;");
+        assertConfStringIsPatched("https::addr=localhost:9000;foo=bar;");
+        assertConfStringIsPatched("https::addr=localhost:9000;auto_flush_rows=1;");
+        assertConfStringIsPatched("https::addr=localhost:9000;auto_flush=on;");
+
+        assertConfStringIsNotPatched("https::addr=localhost:9000;foo=bar;auto_flush_interval=100;");
+        assertConfStringIsNotPatched("https::addr=localhost:9000;foo=bar;auto_flush=off;");
+        assertConfStringIsNotPatched("https::addr=localhost:9000;foo=bar");
+        assertConfStringIsNotPatched("https::addr");
+        assertConfStringIsNotPatched("https");
+        assertConfStringIsNotPatched("tcp::addr=localhost:9000;");
+        assertConfStringIsNotPatched("tcps::addr=localhost:9000;foo=bar;");
+        assertConfStringIsNotPatched("tcps::addr=localhost:9000;auto_flush_rows=1;");
+        assertConfStringIsNotPatched("tcps::addr=localhost:9000;auto_flush=on;");
+        assertConfStringIsNotPatched("unknown::addr=localhost:9000;auto_flush=on;");
+    }
+
+    private static void assertConfStringIsPatched(String confStr) {
+        StringSink sink = new StringSink();
+        ClientConfUtils.patchConfStr(confStr, sink);
+
+        String expected = confStr + "auto_flush_interval=" + Integer.MAX_VALUE + ";";
+        assertTrue(Chars.equals(expected, sink), "Conf string = " + confStr + ", expected = " + expected + ", actual = " + sink);
+    }
+
+    private static void assertConfStringIsNotPatched(String confStr) {
+        StringSink sink = new StringSink();
+        ClientConfUtils.patchConfStr(confStr, sink);
+
+        assertEquals(confStr, sink.toString());
+    }
+
+}

--- a/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
+++ b/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
@@ -57,7 +57,7 @@ public final class ConnectTestUtils {
             props.put("host", ilpIUrl);
         } else {
             int port = questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_HTTP_PORT);
-            confString = "http::addr="+host+":"+ port + ";";
+            confString = "http::addr=" + host + ":" + port + ";";
             props.put("client.conf.string", confString);
         }
         return props;

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -64,7 +64,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
     @BeforeAll
     public static void createContainer() {
-        questDBContainer = newQuestDbConnector();
+        questDBContainer = newQuestDbContainer();
     }
 
     @AfterAll
@@ -85,7 +85,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
     private static GenericContainer<?> questDBContainer;
 
-    private static GenericContainer<?> newQuestDbConnector() {
+    private static GenericContainer<?> newQuestDbContainer() {
         FixedHostPortGenericContainer<?> selfGenericContainer = new FixedHostPortGenericContainer<>(OFFICIAL_QUESTDB_DOCKER);
         if (httpPort != -1) {
             selfGenericContainer = selfGenericContainer.withFixedExposedPort(httpPort, QuestDBUtils.QUESTDB_HTTP_PORT);
@@ -120,7 +120,6 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
         Map<String, String> props = new HashMap<>();
         props.put("connector.client.config.override.policy", "All");
-        props.put("offset.flush.interval.ms", "1000");
         connect = new EmbeddedConnectCluster.Builder()
                 .name("questdb-connect-cluster")
                 .workerProps(props)
@@ -300,7 +299,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         }
 
         // restart QuestDB
-        questDBContainer = newQuestDbConnector();
+        questDBContainer = newQuestDbContainer();
         for (int i = 0; i < 50; i++) {
             connect.kafka().produce(topicName, "key3", "{\"firstname\":\"John\",\"lastname\":\"Doe\",\"age\":" + i + "}");
         }
@@ -541,7 +540,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
     private static void restartQuestDB() {
         questDBContainer.stop();
-        questDBContainer = newQuestDbConnector();
+        questDBContainer = newQuestDbContainer();
     }
 
     @ParameterizedTest

--- a/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
+++ b/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
@@ -297,7 +297,7 @@ public class ExactlyOnceIT {
     }
 
     private static void startConnector() throws IOException, InterruptedException, URISyntaxException {
-        String confString = "http::addr=questdb:9000;auto_flush_rows=10000;auto_flush_interval=" + Integer.MAX_VALUE + ";retry_timeout=60000;";
+        String confString = "http::addr=questdb:9000;auto_flush_rows=10000;retry_timeout=60000;";
 
         String payload = "{\"name\":\"my-connector\",\"config\":{" +
                 "\"tasks.max\":\"4\"," +


### PR DESCRIPTION
the connector has its own mechanism to flush on inactivity, we don't need the client to do this as well.

we disable it only when it's not set explicitly. since if a user sets an explicit flush interval then we can assume they know what they are doing.