### PR TITLE
feat: use auto flush configuration from client config string

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
+++ b/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
@@ -8,6 +8,8 @@ import io.questdb.std.NumericException;
 import io.questdb.std.str.StringSink;
 import org.apache.kafka.common.config.ConfigException;
 
+import java.util.concurrent.TimeUnit;
+
 final class ClientConfUtils {
     private ClientConfUtils() {
     }
@@ -53,7 +55,7 @@ final class ClientConfUtils {
                     throw new ConfigException("QuestDB Kafka connector cannot have auto_flush_interval disabled");
                 }
                 try {
-                    flushConfig.autoFlushNanos = Numbers.parseLong(tmpSink);
+                    flushConfig.autoFlushNanos = TimeUnit.MILLISECONDS.toNanos(Numbers.parseLong(tmpSink));
                 } catch (NumericException e) {
                     throw new ConfigException("Invalid auto_flush_interval value [auto_flush_interval=" + tmpSink + ']');
                 }

--- a/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
+++ b/connector/src/main/java/io/questdb/kafka/ClientConfUtils.java
@@ -2,65 +2,117 @@ package io.questdb.kafka;
 
 import io.questdb.client.impl.ConfStringParser;
 import io.questdb.std.Chars;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.NumericException;
 import io.questdb.std.str.StringSink;
+import org.apache.kafka.common.config.ConfigException;
 
 final class ClientConfUtils {
     private ClientConfUtils() {
     }
 
-    static boolean patchConfStr(String confStr, StringSink sink) {
-        int pos = ConfStringParser.of(confStr, sink);
+
+    static boolean patchConfStr(String confStr, StringSink sink, FlushConfig flushConfig) {
+        flushConfig.reset();
+
+        sink.clear();
+        StringSink tmpSink = Misc.getThreadLocalSink();
+        int pos = ConfStringParser.of(confStr, tmpSink);
         if (pos < 0) {
-            sink.clear();
             sink.put(confStr);
             return false;
         }
 
-        boolean isHttpTransport = Chars.equals(sink, "http") || Chars.equals(sink, "https");
-        boolean intervalFlushSetExplicitly = false;
-        boolean flushesDisabled = false;
-        boolean parseError = false;
-        boolean hasAtLeastOneParam = false;
+        boolean isHttpTransport = Chars.equals(tmpSink, "http") || Chars.equals(tmpSink, "https");
+        if (!isHttpTransport) {
+            sink.put(confStr);
+            // no patching for TCP transport
+            return false;
+        }
+        sink.put(tmpSink).put("::");
 
-        // disable interval based flushes
-        // unless they are explicitly set or auto_flush is entirely off
-        // why? the connector has its own mechanism to flush data in a timely manner
+        boolean hasAtLeastOneParam = false;
         while (ConfStringParser.hasNext(confStr, pos)) {
             hasAtLeastOneParam = true;
-            pos = ConfStringParser.nextKey(confStr, pos, sink);
+            pos = ConfStringParser.nextKey(confStr, pos, tmpSink);
             if (pos < 0) {
-                parseError = true;
-                break;
+                sink.clear();
+                sink.put(confStr);
+                return true;
             }
-            if (Chars.equals(sink, "auto_flush_interval")) {
-                intervalFlushSetExplicitly = true;
-                pos = ConfStringParser.value(confStr, pos, sink);
-            } else if (Chars.equals(sink, "auto_flush")) {
-                pos = ConfStringParser.value(confStr, pos, sink);
-                flushesDisabled = Chars.equals(sink, "off");
+            if (Chars.equals(tmpSink, "auto_flush_interval")) {
+                pos = ConfStringParser.value(confStr, pos, tmpSink);
+                if (pos < 0) {
+                    sink.clear();
+                    sink.put(confStr);
+                    // invalid config, let the real client parser to fail
+                    return true;
+                }
+                if (Chars.equals(tmpSink, "off")) {
+                    throw new ConfigException("QuestDB Kafka connector cannot have auto_flush_interval disabled");
+                }
+                try {
+                    flushConfig.autoFlushNanos = Numbers.parseLong(tmpSink);
+                } catch (NumericException e) {
+                    throw new ConfigException("Invalid auto_flush_interval value [auto_flush_interval=" + tmpSink + ']');
+                }
+            } else if (Chars.equals(tmpSink, "auto_flush_rows")) {
+                pos = ConfStringParser.value(confStr, pos, tmpSink);
+                if (pos < 0) {
+                    sink.clear();
+                    sink.put(confStr);
+                    return true;
+                }
+                if (Chars.equals(tmpSink, "off")) {
+                    throw new ConfigException("QuestDB Kafka connector cannot have auto_flush_rows disabled");
+                } else {
+                    try {
+                        flushConfig.autoFlushRows = Numbers.parseInt(tmpSink);
+                    } catch (NumericException e) {
+                        throw new ConfigException("Invalid auto_flush_rows value [auto_flush_rows=" + tmpSink + ']');
+                    }
+                }
+            } else if (Chars.equals(tmpSink, "auto_flush")) {
+                pos = ConfStringParser.value(confStr, pos, tmpSink);
+                if (pos < 0) {
+                    sink.clear();
+                    sink.put(confStr);
+                    return true;
+                }
+                if (Chars.equals(tmpSink, "off")) {
+                    throw new ConfigException("QuestDB Kafka connector cannot have auto_flush disabled");
+                } else if (!Chars.equals(tmpSink, "on")) {
+                    throw new ConfigException("Unknown auto_flush value [auto_flush=" + tmpSink + ']');
+                }
             } else {
-                pos = ConfStringParser.value(confStr, pos, sink); // skip other values
-            }
-            if (pos < 0) {
-                parseError = true;
-                break;
+                // copy other params
+                sink.put(tmpSink).put('=');
+                pos = ConfStringParser.value(confStr, pos, tmpSink);
+                if (pos < 0) {
+                    sink.clear();
+                    sink.put(confStr);
+                    return true;
+                }
+                for (int i = 0; i < tmpSink.length(); i++) {
+                    char ch = tmpSink.charAt(i);
+                    sink.put(ch);
+                    // re-escape semicolon
+                    if (ch == ';') {
+                        sink.put(';');
+                    }
+                }
+                sink.put(';');
             }
         }
-        sink.clear();
-        sink.put(confStr);
-        if (!parseError // we don't want to mess with the config if there was a parse error
-                && isHttpTransport // we only want to patch http transport
-                && !flushesDisabled // if auto-flush is disabled we don't need to do anything
-                && !intervalFlushSetExplicitly // if auto_flush_interval is set explicitly we don't want to override it
-                && hasAtLeastOneParam // no parameter is also an error since at least address should be set. we let client throw exception in this case
-        ) {
-            // if everything is ok, we set auto_flush_interval to max value
-            // this will effectively disable interval based flushes
-            // and the connector will flush data only when it is told to do so by Connector
-            // or if a row count limit is reached
-            sink.put("auto_flush_interval=").put(Integer.MAX_VALUE).put(';');
+        if (!hasAtLeastOneParam) {
+            // this is invalid, let the real client parser to fail
+            sink.clear();
+            sink.put(confStr);
+            return true;
         }
+        sink.put("auto_flush=off;");
 
-        return isHttpTransport;
+        return true;
     }
 }

--- a/connector/src/main/java/io/questdb/kafka/FlushConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/FlushConfig.java
@@ -2,7 +2,7 @@ package io.questdb.kafka;
 
 import java.util.concurrent.TimeUnit;
 
-class FlushConfig {
+final class FlushConfig {
     int autoFlushRows;
     long autoFlushNanos;
 

--- a/connector/src/main/java/io/questdb/kafka/FlushConfig.java
+++ b/connector/src/main/java/io/questdb/kafka/FlushConfig.java
@@ -1,0 +1,13 @@
+package io.questdb.kafka;
+
+import java.util.concurrent.TimeUnit;
+
+class FlushConfig {
+    int autoFlushRows;
+    long autoFlushNanos;
+
+    void reset() {
+        autoFlushRows = 75_000;
+        autoFlushNanos = TimeUnit.SECONDS.toNanos(1);
+    }
+}

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -169,7 +169,7 @@ public final class QuestDBSinkTask extends SinkTask {
                     if (remainingMs <= 0) {
                         log.debug("Flushing data to QuestDB due to auto_flush_interval timeout");
                         flushAndResetCounters();
-                    } if (allowedLag == 0) {
+                    } else if (allowedLag == 0) {
                         log.debug("Flushing data to QuestDB due to zero allowed lag");
                         flushAndResetCounters();
                     } else {

--- a/connector/src/test/java/io/questdb/kafka/ClientConfUtilsTest.java
+++ b/connector/src/test/java/io/questdb/kafka/ClientConfUtilsTest.java
@@ -65,6 +65,8 @@ public class ClientConfUtilsTest {
         ClientConfUtils.patchConfStr(confStr, sink, flushConfig);
 
         Assert.assertEquals(expectedPatchedConfStr, sink.toString());
+        Assert.assertEquals(expectedMaxPendingRows, flushConfig.autoFlushRows);
+        Assert.assertEquals(expectedFlushNanos, flushConfig.autoFlushNanos);
     }
 
     private static void assertConfStringIsNotPatched(String confStr) {

--- a/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
+++ b/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
@@ -52,13 +52,13 @@ public final class ConnectTestUtils {
         props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
 
         String confString;
-        if (!useHttp) {
-            String ilpIUrl = host + ":" + questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_ILP_PORT);
-            props.put("host", ilpIUrl);
-        } else {
+        if (useHttp) {
             int port = questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_HTTP_PORT);
             confString = "http::addr=" + host + ":" + port + ";";
             props.put("client.conf.string", confString);
+        } else {
+            String ilpIUrl = host + ":" + questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_ILP_PORT);
+            props.put("host", ilpIUrl);
         }
         return props;
     }

--- a/integration-tests/cp-server/src/test/java/io/questdb/kafka/QuestDBSinkConnectorIT.java
+++ b/integration-tests/cp-server/src/test/java/io/questdb/kafka/QuestDBSinkConnectorIT.java
@@ -66,7 +66,7 @@ public class QuestDBSinkConnectorIT {
             .withEnv("CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR", "1")
             .withEnv("CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR", "1")
             .withEnv("CONNECT_STATUS_STORAGE_REPLICATION_FACTOR", "1")
-            .withEnv("QDB_CLIENT_CONF", "http::addr=questdb;auto_flush=off;") // intentionally disabled auto-flush
+            .withEnv("QDB_CLIENT_CONF", "http::addr=questdb;")
             .withNetwork(network)
             .withExposedPorts(8083)
             .withCopyFileToContainer(MountableFile.forHostPath(connectorJarResolver.getJarPath()), "/usr/share/java/kafka/questdb-connector.jar")

--- a/integration-tests/debezium/src/test/java/kafka/DebeziumIT.java
+++ b/integration-tests/debezium/src/test/java/kafka/DebeziumIT.java
@@ -63,8 +63,7 @@ public class DebeziumIT {
                     .dependsOn(kafkaContainer)
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("debezium")))
                     .withEnv("CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE", "true")
-                    .withEnv("CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE", "true")
-                    .withEnv("OFFSET_FLUSH_INTERVAL_MS", "1000");
+                    .withEnv("CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE", "true");
 
     @Container
     private final GenericContainer<?> questDBContainer = new GenericContainer<>("questdb/questdb:7.4.0")

--- a/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
+++ b/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
@@ -171,7 +171,6 @@ public class ExactlyOnceIT {
         return new GenericContainer<>(CONNECT_CONTAINER_IMAGE)
                 .withEnv("CONNECT_BOOTSTRAP_SERVERS", "kafka0:9092")
                 .withEnv("CONNECT_GROUP_ID", "test")
-                .withEnv("CONNECT_OFFSET_FLUSH_INTERVAL_MS", "5000")
                 .withEnv("CONNECT_OFFSET_STORAGE_TOPIC", "connect-storage-topic")
                 .withEnv("CONNECT_CONFIG_STORAGE_TOPIC", "connect-config-topic")
                 .withEnv("CONNECT_STATUS_STORAGE_TOPIC", "connect-status-topic")

--- a/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
+++ b/integration-tests/exactlyonce/src/test/java/io/questdb/kafka/ExactlyOnceIT.java
@@ -297,7 +297,7 @@ public class ExactlyOnceIT {
     }
 
     private static void startConnector() throws IOException, InterruptedException, URISyntaxException {
-        String confString = "http::addr=questdb:9000;auto_flush_rows=10000;retry_timeout=60000;";
+        String confString = "http::addr=questdb:9000;retry_timeout=60000;";
 
         String payload = "{\"name\":\"my-connector\",\"config\":{" +
                 "\"tasks.max\":\"4\"," +


### PR DESCRIPTION
Connector flushing behaviour should now be more intuitive: 
1. It's configured via client conf. string as all other clients. 
2. If there are no new events for the duration of the `allowed.lag` period then the connector flushes even if the `auto_flush_interval` is not yet expired. This reduces latency without sacrificing maximum throughput: If there is a continuous stream of events then the connector will flush only when either `auto_flush_interval` expires or the connector accumulates more than `auto_flush_rows` rows.


**Implementation notes**
The connector reads flushing parameters from client configuration string. The conf. string is then patched to disable flushing entirely and this patched string is used to create an ILP client instance. This means the client won't ever auto-flush on its own and the connector is solely responsible for calling explicit `flush()`. This design has performance advantages: Kafka Connect delivers messages in batches and the connector can flush after only finishing the current batch. This has performance advantages over flushing mid-batch. 