### PR TITLE
request offset commit after a successful flush()

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -224,6 +224,7 @@ public final class QuestDBSinkTask extends SinkTask {
             if (sender != null) {
                 sender.flush();
             }
+            context.requestCommit();
             nextFlushNanos = System.nanoTime() + flushConfig.autoFlushNanos;
             pendingRows = 0;
         } catch (LineSenderException | HttpClientException e) {


### PR DESCRIPTION
This limits the number of duplicates QuestDB
server has to deal with after error recovery