### PR TITLE
feat: DQL for client-side validations failures

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/BufferingSender.java
+++ b/connector/src/main/java/io/questdb/kafka/BufferingSender.java
@@ -98,6 +98,24 @@ final class BufferingSender implements Sender {
     }
 
     @Override
+    public void cancelRow() {
+        symbolColumnNames.clear();
+        symbolColumnValues.clear();
+        stringNames.clear();
+        stringValues.clear();
+        longNames.clear();
+        longValues.clear();
+        doubleNames.clear();
+        doubleValues.clear();
+        boolNames.clear();
+        boolValues.clear();
+        timestampNames.clear();
+        timestampValues.clear();
+
+        sender.cancelRow();
+    }
+
+    @Override
     public Sender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
         if (symbolColumns.contains(name)) {
             symbolColumnNames.add(name);

--- a/connector/src/main/java/io/questdb/kafka/InvalidDataException.java
+++ b/connector/src/main/java/io/questdb/kafka/InvalidDataException.java
@@ -8,7 +8,7 @@ public final class InvalidDataException extends ConnectException {
         super(message);
     }
 
-    public InvalidDataException(String message, NumericException e) {
+    public InvalidDataException(String message, Throwable e) {
         super(message, e);
     }
 }

--- a/connector/src/main/java/io/questdb/kafka/InvalidDataException.java
+++ b/connector/src/main/java/io/questdb/kafka/InvalidDataException.java
@@ -1,0 +1,14 @@
+package io.questdb.kafka;
+
+import io.questdb.std.NumericException;
+import org.apache.kafka.connect.errors.ConnectException;
+
+public final class InvalidDataException extends ConnectException {
+    public InvalidDataException(String message) {
+        super(message);
+    }
+
+    public InvalidDataException(String message, NumericException e) {
+        super(message, e);
+    }
+}

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -318,9 +318,9 @@ public final class QuestDBSinkTask extends SinkTask {
         if (tableName == null || tableName.equals("")) {
             throw new InvalidDataException("Table name cannot be empty");
         }
-        sender.table(tableName);
 
         try {
+            sender.table(tableName);
             if (config.isIncludeKey()) {
                 handleObject(config.getKeyPrefix(), record.keySchema(), record.key(), PRIMITIVE_KEY_FALLBACK_NAME);
             }
@@ -330,6 +330,11 @@ public final class QuestDBSinkTask extends SinkTask {
                 sender.cancelRow();
             }
             throw ex;
+        } catch (LineSenderException ex) {
+            if (httpTransport) {
+                sender.cancelRow();
+            }
+            throw new InvalidDataException("object contains invalid data", ex);
         }
 
         if (kafkaTimestampsEnabled) {

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public final class QuestDBSinkConnectorEmbeddedTest {
     private static int httpPort = -1;
     private static int ilpPort = -1;
-    private static final String OFFICIAL_QUESTDB_DOCKER = "questdb/questdb:8.1.1";
+    private static final String OFFICIAL_QUESTDB_DOCKER = "questdb/questdb:8.2.0";
     private static final boolean DUMP_QUESTDB_CONTAINER_LOGS = true;
 
     private EmbeddedConnectCluster connect;

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>7.4.0</version>
+            <version>8.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
When an individual message fails client-side validation then we send this message to DQL (if configured)

Resolves https://github.com/questdb/kafka-questdb-connector/issues/26
TODO:
- [x] test errors from originating in ILP client