### PR TITLE
Support for QuestDB arrays

### DIFF
--- a/connector/src/main/java/io/questdb/kafka/BufferingSender.java
+++ b/connector/src/main/java/io/questdb/kafka/BufferingSender.java
@@ -1,8 +1,11 @@
 package io.questdb.kafka;
 
 import io.questdb.client.Sender;
+import io.questdb.cutlass.line.array.DoubleArray;
+import io.questdb.cutlass.line.array.LongArray;
 import io.questdb.std.BoolList;
 import io.questdb.std.LongList;
+import io.questdb.std.bytes.DirectByteSlice;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -95,6 +98,11 @@ final class BufferingSender implements Sender {
             boolValues.add(value);
         }
         return this;
+    }
+
+    @Override
+    public DirectByteSlice bufferView() {
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
@@ -229,5 +237,45 @@ final class BufferingSender implements Sender {
     @Override
     public void close() {
         sender.close();
+    }
+
+    @Override
+    public Sender doubleArray(CharSequence charSequence, double[] doubles) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender doubleArray(CharSequence charSequence, double[][] doubles) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender doubleArray(CharSequence charSequence, double[][][] doubles) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender doubleArray(CharSequence charSequence, DoubleArray doubleArray) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender longArray(CharSequence charSequence, long[] longs) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender longArray(CharSequence charSequence, long[][] longs) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender longArray(CharSequence charSequence, long[][][] longs) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Sender longArray(CharSequence charSequence, LongArray longArray) {
+        throw new UnsupportedOperationException("not implemented");
     }
 }

--- a/connector/src/main/java/io/questdb/kafka/BufferingSender.java
+++ b/connector/src/main/java/io/questdb/kafka/BufferingSender.java
@@ -37,6 +37,8 @@ final class BufferingSender implements Sender {
     private final List<CharSequence> symbolColumnNames = new ArrayList<>(DEFAULT_CAPACITY);
     private final List<CharSequence> symbolColumnValues = new ArrayList<>(DEFAULT_CAPACITY);
     private final Set<CharSequence> symbolColumns = new HashSet<>();
+    private final List<CharSequence> doubleArrayNames = new ArrayList<>(DEFAULT_CAPACITY);
+    private final List<double[]> doubleArrayValues = new ArrayList<>(DEFAULT_CAPACITY);
 
     BufferingSender(Sender sender, String symbolColumns) {
         this.sender = sender;
@@ -201,6 +203,14 @@ final class BufferingSender implements Sender {
         }
         timestampNames.clear();
         timestampValues.clear();
+
+        for (int i = 0, n = doubleArrayNames.size(); i < n; i++) {
+            CharSequence fieldName = doubleArrayNames.get(i);
+            double[] fieldValue = doubleArrayValues.get(i);
+            sender.doubleArray(fieldName, fieldValue);
+        }
+        doubleArrayNames.clear();
+        doubleArrayValues.clear();
     }
 
     private static long unitToMicros(long value, ChronoUnit unit) {
@@ -241,7 +251,9 @@ final class BufferingSender implements Sender {
 
     @Override
     public Sender doubleArray(CharSequence charSequence, double[] doubles) {
-        throw new UnsupportedOperationException("not implemented");
+        doubleArrayNames.add(charSequence);
+        doubleArrayValues.add(doubles);
+        return this;
     }
 
     @Override

--- a/connector/src/main/java/io/questdb/kafka/BufferingSender.java
+++ b/connector/src/main/java/io/questdb/kafka/BufferingSender.java
@@ -39,6 +39,10 @@ final class BufferingSender implements Sender {
     private final Set<CharSequence> symbolColumns = new HashSet<>();
     private final List<CharSequence> doubleArrayNames = new ArrayList<>(DEFAULT_CAPACITY);
     private final List<double[]> doubleArrayValues = new ArrayList<>(DEFAULT_CAPACITY);
+    private final List<CharSequence> doubleArray2DNames = new ArrayList<>(DEFAULT_CAPACITY);
+    private final List<double[][]> doubleArray2DValues = new ArrayList<>(DEFAULT_CAPACITY);
+    private final List<CharSequence> doubleArray3DNames = new ArrayList<>(DEFAULT_CAPACITY);
+    private final List<double[][][]> doubleArray3DValues = new ArrayList<>(DEFAULT_CAPACITY);
 
     BufferingSender(Sender sender, String symbolColumns) {
         this.sender = sender;
@@ -121,6 +125,12 @@ final class BufferingSender implements Sender {
         boolValues.clear();
         timestampNames.clear();
         timestampValues.clear();
+        doubleArrayNames.clear();
+        doubleArrayValues.clear();
+        doubleArray2DNames.clear();
+        doubleArray2DValues.clear();
+        doubleArray3DNames.clear();
+        doubleArray3DValues.clear();
 
         sender.cancelRow();
     }
@@ -211,6 +221,22 @@ final class BufferingSender implements Sender {
         }
         doubleArrayNames.clear();
         doubleArrayValues.clear();
+
+        for (int i = 0, n = doubleArray2DNames.size(); i < n; i++) {
+            CharSequence fieldName = doubleArray2DNames.get(i);
+            double[][] fieldValue = doubleArray2DValues.get(i);
+            sender.doubleArray(fieldName, fieldValue);
+        }
+        doubleArray2DNames.clear();
+        doubleArray2DValues.clear();
+
+        for (int i = 0, n = doubleArray3DNames.size(); i < n; i++) {
+            CharSequence fieldName = doubleArray3DNames.get(i);
+            double[][][] fieldValue = doubleArray3DValues.get(i);
+            sender.doubleArray(fieldName, fieldValue);
+        }
+        doubleArray3DNames.clear();
+        doubleArray3DValues.clear();
     }
 
     private static long unitToMicros(long value, ChronoUnit unit) {
@@ -258,12 +284,16 @@ final class BufferingSender implements Sender {
 
     @Override
     public Sender doubleArray(CharSequence charSequence, double[][] doubles) {
-        throw new UnsupportedOperationException("not implemented");
+        doubleArray2DNames.add(charSequence);
+        doubleArray2DValues.add(doubles);
+        return this;
     }
 
     @Override
     public Sender doubleArray(CharSequence charSequence, double[][][] doubles) {
-        throw new UnsupportedOperationException("not implemented");
+        doubleArray3DNames.add(charSequence);
+        doubleArray3DValues.add(doubles);
+        return this;
     }
 
     @Override

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -577,6 +577,7 @@ public final class QuestDBSinkTask extends SinkTask {
             }
             sender.doubleArray(name, doubleArray);
         } else if (elementType == Schema.Type.ARRAY) {
+            // todo: handle multidimensional arrays
             onUnsupportedType(name, "Multidimensional ARRAY");
         } else {
             onUnsupportedType(name, "ARRAY<" + elementType + ">");

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -754,8 +754,8 @@ public final class QuestDBSinkTask extends SinkTask {
                 
                 if (firstNestedNestedElement instanceof Number) {
                     // First, validate dimensions for 3D array (no jagged arrays)
-                    int expectedMatrixHeight = firstNestedList.size();
-                    int expectedRowLength = firstNestedList.size() > 0 ? ((List<?>) firstNestedList.get(0)).size() : 0;
+                    int expectedMatrixHeight = firstList.size();
+                    int expectedRowLength = firstNestedList.size();
                     
                     for (int i = 0; i < list.size(); i++) {
                         Object matrix = list.get(i);

--- a/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
+++ b/connector/src/main/java/io/questdb/kafka/QuestDBSinkTask.java
@@ -325,19 +325,21 @@ public final class QuestDBSinkTask extends SinkTask {
             throw new InvalidDataException("Table name cannot be empty");
         }
 
+        boolean partialRecord = false;
         try {
             sender.table(tableName);
+            partialRecord = true;
             if (config.isIncludeKey()) {
                 handleObject(config.getKeyPrefix(), record.keySchema(), record.key(), PRIMITIVE_KEY_FALLBACK_NAME);
             }
             handleObject(config.getValuePrefix(), record.valueSchema(), recordValue, PRIMITIVE_VALUE_FALLBACK_NAME);
         } catch (InvalidDataException ex) {
-            if (httpTransport) {
+            if (httpTransport && partialRecord) {
                 sender.cancelRow();
             }
             throw ex;
         } catch (LineSenderException ex) {
-            if (httpTransport) {
+            if (httpTransport && partialRecord) {
                 sender.cancelRow();
             }
             throw new InvalidDataException("object contains invalid data", ex);

--- a/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
+++ b/connector/src/test/java/io/questdb/kafka/ConnectTestUtils.java
@@ -57,8 +57,9 @@ public final class ConnectTestUtils {
             confString = "http::addr=" + host + ":" + port + ";";
             props.put("client.conf.string", confString);
         } else {
-            String ilpIUrl = host + ":" + questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_ILP_PORT);
-            props.put("host", ilpIUrl);
+            int port = questDBContainer.getMappedPort(QuestDBUtils.QUESTDB_ILP_PORT);
+            confString = "tcp::addr=" + host + ":" + port + ";protocol_version=2;";
+            props.put("client.conf.string", confString);
         }
         return props;
     }

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public final class QuestDBSinkConnectorEmbeddedTest {
     private static int httpPort = -1;
     private static int ilpPort = -1;
-    private static final String OFFICIAL_QUESTDB_DOCKER = "questdb/questdb:8.2.0";
+    private static final String OFFICIAL_QUESTDB_DOCKER = "questdb/questdb:9.0.1";
     private static final boolean DUMP_QUESTDB_CONTAINER_LOGS = true;
 
     private EmbeddedConnectCluster connect;
@@ -957,7 +957,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
         // make sure we have all records in the table
         QuestDBUtils.assertSqlEventually(
-                "\"count\"\r\n"
+                "\"count()\"\r\n"
                         + recordCount + "\r\n",
                 "select count(*) from " + topicName,
                 600,
@@ -1545,15 +1545,28 @@ public final class QuestDBSinkConnectorEmbeddedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testJsonNoSchema_ArrayNotSupported(boolean useHttp) {
+    public void testJsonNoSchema_intArraySendAsDoubleArray(boolean useHttp) {
+        // In schema-less mode, we have to be lenient with array element types.
+        // Since floating point numbers without any actual decimal point are
+        // instantiated as integers by Kafka Connect.
+        //
+        // This will become problematic once QuestDB supports arrays of integers,
+        // as it will not be able to distinguish between an array of integers and
+        // an array of doubles.
+        // For now, we just assume that all arrays are of doubles.
+
+
         connect.kafka().createTopic(topicName, 1);
         Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, useHttp);
         props.put("value.converter.schemas.enable", "false");
         connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
         ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
-        connect.kafka().produce(topicName, "key", "{\"firstname\":\"John\",\"lastname\":\"Doe\",\"age\":42,\"array\":[1,2,3]}");
+        connect.kafka().produce(topicName, "key", "{\"firstname\":\"John\",\"lastname\":\"Doe\",\"age\":42,\"arr\":[1,2,3]}");
 
-        ConnectTestUtils.assertConnectorTaskFailedEventually(connect);
+        QuestDBUtils.assertSqlEventually("\"firstname\",\"lastname\",\"age\",\"arr\"\r\n"
+                        + "\"John\",\"Doe\",42,\"[1.0,2.0,3.0]\"\r\n",
+                "select firstname,lastname,age,arr from " + topicName,
+                httpPort);
     }
 
     @ParameterizedTest
@@ -2015,5 +2028,225 @@ public final class QuestDBSinkConnectorEmbeddedTest {
                         + "\"John\",\"Doe\",\"Jane\",\"Doe\"\r\n",
                 "select partner1_name_firstname, partner1_name_lastname, partner2_name_firstname, partner2_name_lastname from " + topicName,
                 httpPort);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFloat32ArraySupport(boolean useHttp) {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, useHttp);
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Create schema with float array
+        Schema arraySchema = SchemaBuilder.array(Schema.FLOAT32_SCHEMA).build();
+        Schema schema = SchemaBuilder.struct()
+                .name("com.example.Measurement")
+                .field("sensor_id", Schema.STRING_SCHEMA)
+                .field("readings", arraySchema)
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("sensor_id", "sensor1")
+                .put("readings", Arrays.asList(23.5f, 24.1f, 23.8f));
+
+        connect.kafka().produce(topicName, new String(converter.fromConnectData(topicName, schema, struct)));
+
+        QuestDBUtils.assertSqlEventually(
+                "\"sensor_id\",\"readings\"\r\n" +
+                "\"sensor1\",\"[23.5,24.100000381469727,23.799999237060547]\"\r\n",
+                "select sensor_id, readings from " + topicName,
+                httpPort
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFloat64ArraySupport(boolean useHttp) {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, useHttp);
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Create schema with double array
+        Schema arraySchema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
+        Schema schema = SchemaBuilder.struct()
+                .name("com.example.Measurement")
+                .field("device", Schema.STRING_SCHEMA)
+                .field("temperatures", arraySchema)
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("device", "thermometer1")
+                .put("temperatures", Arrays.asList(98.6, 99.1, 97.9));
+
+        connect.kafka().produce(topicName, new String(converter.fromConnectData(topicName, schema, struct)));
+
+        QuestDBUtils.assertSqlEventually(
+                "\"device\",\"temperatures\"\r\n" +
+                "\"thermometer1\",\"[98.6,99.1,97.9]\"\r\n",
+                "select device, temperatures from " + topicName,
+                httpPort
+        );
+    }
+
+    @Test
+    public void testSchemalessFloatArraySupport() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, true);
+        props.put("value.converter.schemas.enable", "false");
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Send JSON with array of doubles
+        String json = "{\"location\":\"room1\",\"humidity_readings\":[45.2,46.8,44.9]}";
+        connect.kafka().produce(topicName, json);
+
+        QuestDBUtils.assertSqlEventually(
+                "\"location\",\"humidity_readings\"\r\n" +
+                "\"room1\",\"[45.2,46.8,44.9]\"\r\n",
+                "select location, humidity_readings from " + topicName,
+                httpPort
+        );
+    }
+
+    @Test
+    public void testSchemalessFloatArraySupport_floatFollowedByInt() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, true);
+        props.put("value.converter.schemas.enable", "false");
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Send JSON with array of doubles
+        String json = "{\"location\":\"room1\",\"humidity_readings\":[45.0,46,44.9]}";
+        connect.kafka().produce(topicName, json);
+
+        QuestDBUtils.assertSqlEventually(
+                "\"location\",\"humidity_readings\"\r\n" +
+                        "\"room1\",\"[45.0,46.0,44.9]\"\r\n",
+                "select location, humidity_readings from " + topicName,
+                httpPort
+        );
+    }
+
+    @Test
+    public void testSchemalessFloatArraySupport_intFollowedByFloat() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, true);
+        props.put("value.converter.schemas.enable", "false");
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Send JSON with array of doubles
+        String json = "{\"location\":\"room1\",\"humidity_readings\":[45,46.0,44.9]}";
+        connect.kafka().produce(topicName, json);
+
+        QuestDBUtils.assertSqlEventually(
+                "\"location\",\"humidity_readings\"\r\n" +
+                        "\"room1\",\"[45.0,46.0,44.9]\"\r\n",
+                "select location, humidity_readings from " + topicName,
+                httpPort
+        );
+    }
+
+
+    @Test
+    public void testIntegerArrayRejection() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, true);
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        props.put("errors.tolerance", "none");
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Create schema with integer array (should fail)
+        Schema arraySchema = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
+        Schema schema = SchemaBuilder.struct()
+                .name("com.example.Counter")
+                .field("name", Schema.STRING_SCHEMA)
+                .field("counts", arraySchema)
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("name", "counter1")
+                .put("counts", Arrays.asList(1, 2, 3));
+
+        connect.kafka().produce(topicName, new String(converter.fromConnectData(topicName, schema, struct)));
+
+        // The connector should fail to process this record
+        ConnectTestUtils.assertConnectorTaskFailedEventually(connect);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testNestedStructWithArray(boolean useHttp) {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, useHttp);
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        Schema arraySchema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
+        Schema sensorSchema = SchemaBuilder.struct()
+                .field("type", Schema.STRING_SCHEMA)
+                .field("values", arraySchema)
+                .build();
+        Schema schema = SchemaBuilder.struct()
+                .name("com.example.Device")
+                .field("id", Schema.STRING_SCHEMA)
+                .field("sensor", sensorSchema)
+                .build();
+
+        Struct sensorStruct = new Struct(sensorSchema)
+                .put("type", "temperature")
+                .put("values", Arrays.asList(20.5, 21.0, 20.8));
+
+        Struct struct = new Struct(schema)
+                .put("id", "device1")
+                .put("sensor", sensorStruct);
+
+        connect.kafka().produce(topicName, new String(converter.fromConnectData(topicName, schema, struct)));
+
+        QuestDBUtils.assertSqlEventually(
+                "\"id\",\"sensor_type\",\"sensor_values\"\r\n" +
+                "\"device1\",\"temperature\",\"[20.5,21.0,20.8]\"\r\n",
+                "select id, sensor_type, sensor_values from " + topicName,
+                httpPort
+        );
+    }
+
+    @Test
+    public void testArrayWithSkipUnsupportedTypes() {
+        connect.kafka().createTopic(topicName, 1);
+        Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, true);
+        props.put("skip.unsupported.types", "true");
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
+        ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
+
+        // Create schema with string array (unsupported)
+        Schema arraySchema = SchemaBuilder.array(Schema.STRING_SCHEMA).build();
+        Schema schema = SchemaBuilder.struct()
+                .name("com.example.Data")
+                .field("names", arraySchema)
+                .field("value", Schema.FLOAT64_SCHEMA)
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("names", Arrays.asList("a", "b", "c"))
+                .put("value", 42.0);
+
+        connect.kafka().produce(topicName, new String(converter.fromConnectData(topicName, schema, struct)));
+
+        // Verify - string array should be skipped but double field should be written
+        QuestDBUtils.assertSqlEventually(
+                "\"value\"\r\n" +
+                "42.0\r\n",
+                "select value from " + topicName,
+                httpPort
+        );
     }
 }

--- a/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
+++ b/connector/src/test/java/io/questdb/kafka/QuestDBSinkConnectorEmbeddedTest.java
@@ -2067,6 +2067,7 @@ public final class QuestDBSinkConnectorEmbeddedTest {
         connect.kafka().createTopic(topicName, 1);
         Map<String, String> props = ConnectTestUtils.baseConnectorProps(questDBContainer, topicName, useHttp);
         props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        props.put(QuestDBSinkConnectorConfig.SYMBOL_COLUMNS_CONFIG, "devices");
         connect.configureConnector(ConnectTestUtils.CONNECTOR_NAME, props);
         ConnectTestUtils.assertConnectorTaskRunningEventually(connect);
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>8.2.0</version>
+            <version>9.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## What This Enables

This PR allows you to stream multi-dimensional array data from Kafka to QuestDB.

Previously, any message containing arrays would cause the connector to crash with `Unsupported type` errors. Now you can store sensor readings, machine learning features, financial time series, and other array-based data.

## Real-World Use Cases Now Supported

IoT & Sensor Data
```json
{
  "device_id": "sensor_001",
  "temperature_readings": [20.1, 20.3, 20.5, 20.7],
  "location": "warehouse_a"
}
```

Machine Learning Features
```json
{
  "model_id": "classifier_v2",
  "feature_matrix": [[0.1, 0.8], [0.3, 0.6], [0.9, 0.2]],
  "prediction_confidence": 0.94
}
```

Financial Market Data
```json
{
  "symbol": "AAPL",
  "ohlc_5min": [[150.1, 151.2, 149.8, 150.9], [150.9, 152.1, 150.3, 151.5]],
  "volume": [12500, 13200]
}
```

Your array data flows through to QuestDB and gets stored as native arrays, queryable with QuestDB's array functions.


## Data Format Support

### With Kafka Connect Schema
```
// Your existing schema definitions work
Schema arraySchema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
```

### Schema-Free JSON (Most Common)
```
// Just send your JSON - arrays are auto-detected
{"sensor_data": [23.1, 24.5, 22.8]}`
```

### Current Limitations

Supported

- 1D, 2D, 3D arrays (current QuestDB version)
-  Numeric data (integers and floats)
-  Both schema and schema-free Kafka messages
-  Nested arrays in complex JSON structures

Not Yet Supported

-  String arrays - ["apple", "banana"]
-  Mixed-type arrays - [1, "text", 3.14]
-  Null elements - [1.0, null, 3.0]]
-  Empty Arrays - this is a temporary limitation, empty arrays will be supported in future versions

Future Support

-  Up to 32 dimensions coming in next QuestDB version
-  Performance optimizations